### PR TITLE
Global theme reference

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,40 +1,7 @@
-// const path = require('path');
-//
-// module.exports = {
-//   module: {
-//     loaders: [
-//       {
-//         test: /\.scss$/,
-//         loaders: [
-//           'style',
-//           'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
-//           'postcss',
-//           'sass',
-//         ],
-//         exclude: path.resolve(__dirname, '../src/styles'),
-//       },
-//       {
-//         test: /\.scss$/,
-//         loaders: ['style', 'css', 'sass'],
-//         include: path.resolve(__dirname, '../src/styles'),
-//       },
-//       { test: /\.woff(\?.*)?$/,  loader: 'url?prefix=fonts/&name=[path][name].[ext]&limit=10000&mimetype=application/font-woff' },
-//       { test: /\.woff2(\?.*)?$/, loader: 'url?prefix=fonts/&name=[path][name].[ext]&limit=10000&mimetype=application/font-woff2' },
-//       { test: /\.otf(\?.*)?$/,   loader: 'file?prefix=fonts/&name=[path][name].[ext]&limit=10000&mimetype=font/opentype' },
-//       { test: /\.ttf(\?.*)?$/,   loader: 'url?prefix=fonts/&name=[path][name].[ext]&limit=10000&mimetype=application/octet-stream' },
-//       { test: /\.eot(\?.*)?$/,   loader: 'file?prefix=fonts/&name=[path][name].[ext]' },
-//       { test: /\.svg(\?.*)?$/,   loader: 'url?prefix=fonts/&name=[path][name].[ext]&limit=10000&mimetype=image/svg+xml' },
-//       { test: /\.(png|jpg)$/,    loader: 'url?limit=8192' },
-//     ],
-//   },
-//   resolve: {
-//     root: path.resolve(__dirname, '../src'),
-//     extensions: ['', '.js', '.jsx'],
-//   },
-// };
-
 const path = require('path');
 const cssnano = require('cssnano');
+const webpack = require('webpack');
+const argv = require('yargs').argv;
 
 const clientPath = path.resolve(__dirname, '../src');
 const stylesPath = path.resolve(__dirname, '../src/styles');
@@ -49,6 +16,32 @@ const webpackConfig = {
   },
   module: {},
 };
+
+// ------------------------------------
+// Plugins
+// ------------------------------------
+/*
+  Until I figure out how to get the Storybook webpack config
+  to run with babel (to support import/export) I have to just copy this
+  from 'config' instead of importing it from there.
+  This might help: https://github.com/kadirahq/react-storybook/issues/155
+*/
+const env = process.env.NODE_ENV || 'development';
+webpackConfig.plugins = [
+  new webpack.DefinePlugin({
+    'process.env': {
+      'NODE_ENV': JSON.stringify(env),
+    },
+    'NODE_ENV': env,
+    '__DEV__': env === 'development',
+    '__PROD__': env === 'production',
+    '__TEST__': env === 'test',
+    '__DEBUG__': env === 'development' && !argv.no_debug,
+    '__COVERAGE__': !argv.watch && env === 'test',
+    '__BASENAME__': JSON.stringify(process.env.BASENAME || ''),
+  }),
+];
+
 
 // ------------------------------------
 // Loaders

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -67,7 +67,8 @@ if (__DEV__) {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   );
-} else if (__PROD__) {
+}
+else if (__PROD__) {
   debug('Enable plugins for production (OccurenceOrder, Dedupe & UglifyJS).');
   webpackConfig.plugins.push(
     new webpack.optimize.OccurrenceOrderPlugin(),

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "react-addons-test-utils": "^15.3.0",
     "redbox-react": "^1.2.10",
     "redux-ava": "^2.1.0",
+    "sass-variable-loader": "0.0.4",
     "sinon": "^1.17.3",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.6.0"

--- a/src/components/GlobalNav/GlobalNav.jsx
+++ b/src/components/GlobalNav/GlobalNav.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import IconButton from 'material-ui/IconButton';
 import { Toolbar, ToolbarGroup, ToolbarTitle, ToolbarSeparator } from 'material-ui/Toolbar';
 import { Icon } from 'react-fa';
+import { palette } from 'styles/muiTheme';
 import RoleSwitcher from './RoleSwitcher';
 import classes from './GlobalNav.scss';
 
 const styles = {
   toolbar: {
-    backgroundColor: 'rgb(15, 147, 166)',
+    backgroundColor: palette.primary1Color,
   },
   separator: {
     backgroundColor: 'rgb(184, 222, 228)',
@@ -18,7 +19,7 @@ const styles = {
     fontSize: '0.9rem',
   },
   title: {
-    color: 'rgb(255, 255, 255)',
+    color: palette.alternateTextColor,
     fontSize: '1rem',
   },
 };

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -7,3 +7,4 @@ can easily be swapped out without `core.scss` ever having to know.
 
 @import './base/variables';
 @import './base/typography';
+@import './base/colors';

--- a/src/styles/base/_colors.scss
+++ b/src/styles/base/_colors.scss
@@ -1,0 +1,6 @@
+$primary1Color: #0F94a7;
+$primary2Color: #485566;
+$accent1Color: #91C383;
+$alternateTextColor: #FFFFFF;
+$borderColor: #DADDE0;
+$textColor: #485566;

--- a/src/styles/muiTheme.js
+++ b/src/styles/muiTheme.js
@@ -1,15 +1,18 @@
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import colors from '!!sass-variable-loader!./base/_colors.scss';
+
+export const palette = {
+  primary1Color: colors.primary1Color,
+  primary2Color: colors.primary2Color,
+  accent1Color: colors.accent1Color,
+  alternateTextColor: colors.alternateTextColor,
+  borderColor: colors.borderColor,
+  textColor: colors.textColor,
+};
 
 const muiTheme = getMuiTheme({
   fontFamily: 'Helvetica Neue',
-  palette: {
-    primary1Color: '#0F94A7',
-    primary2Color: '#485566',
-    accent1Color: '#91C383',
-    alternateTextColor: '#FFFFFF',
-    borderColor: '#DADDE0',
-    textColor: '#485566',
-  },
+  palette,
 });
 
 export default muiTheme;


### PR DESCRIPTION
Add a way to reference global theme colors as variables IE:
```javascript
import { palette } from 'styles/muitheme';

const styles = {
  backgroundColor: palette.primary1Color,
}
```

Also directly within sass
```sass
.someThing {
  color: $textColor;
  background-color: $accent1Color;
}
```

This PR also includes some fixes to the storybook webpack config.