### PR TITLE
Renaming to controller

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,5 @@
 // within webpack helps prevent unexpected errors.
 {
   "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["transform-runtime", "transform-inline-environment-variables"]
+  "plugins": ["transform-runtime" ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,5 @@
 // within webpack helps prevent unexpected errors.
 {
   "presets": ["es2015", "react", "stage-0"],
-  "plugins": ["transform-runtime"]
+  "plugins": ["transform-runtime", "transform-inline-environment-variables"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
     "__PROD__"     : false,
     "__DEBUG__"    : false,
     "__COVERAGE__" : false,
-    "__BASENAME__" : false
+    "__BASENAME__" : false,
+    "__CONTROLLER_API__" : false
   },
   "rules": {
     "global-require": [0],

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
+  - "5"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ These are global variables available to you anywhere in your source code. If you
 |`__TEST__`|True when `process.env.NODE_ENV` is `test`|
 |`__DEBUG__`|True when `process.env.NODE_ENV` is `development` and cli arg `--no_debug` is not set (`npm run dev:no-debug`)|
 |`__BASENAME__`|[history basename option](https://github.com/rackt/history/blob/master/docs/BasenameSupport.md)|
+|`__CONTROLLER_API__`|The API endpoint for the Logistics Wizard Controller. It is initialized from `process.env.CONTROLLER_SERVICE` variable specified as *https://host:port*. The Controller API prefix */api/v1/* is added automatically.|
 
 ### Styles
 

--- a/config/ava.config.js
+++ b/config/ava.config.js
@@ -38,3 +38,6 @@ global['__TEST__'] = env === 'test';
 global['__DEBUG__'] = env === 'development' && !argv.no_debug;
 global['__COVERAGE__'] = !argv.watch && env === 'test';
 global['__BASENAME__'] = JSON.stringify(process.env.BASENAME || '');
+
+const controller_service = process.env.CONTROLLER_SERVICE || 'https://not.set.net';
+global['__CONTROLLER_API__'] = `${controller_service}/api/v1`;

--- a/config/index.js
+++ b/config/index.js
@@ -33,7 +33,7 @@ const config = {
   // ----------------------------------
   // Controller Service Configuration
   // ----------------------------------
-  controller_service : process.env.CONTROLLER_SERVICE || 'https://notset',
+  controller_service : process.env.CONTROLLER_SERVICE || 'https://not.set.net',
 
   // ----------------------------------
   // Compiler Configuration

--- a/config/index.js
+++ b/config/index.js
@@ -31,6 +31,11 @@ const config = {
   server_port : process.env.PORT || 3000,
 
   // ----------------------------------
+  // Controller Service Configuration
+  // ----------------------------------
+  controller_service : process.env.CONTROLLER_SERVICE || 'https://notset',
+
+  // ----------------------------------
   // Compiler Configuration
   // ----------------------------------
   compiler_css_modules     : true,
@@ -78,6 +83,7 @@ config.globals = {
   '__DEBUG__'    : config.env === 'development' && !argv.no_debug,
   '__COVERAGE__' : !argv.watch && config.env === 'test',
   '__BASENAME__' : JSON.stringify(process.env.BASENAME || ''),
+  '__CONTROLLER_API__' : JSON.stringify(`${config.controller_service}/api/v1`),
 };
 
 // ------------------------------------

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.3.17",
     "babel-loader": "^6.2.0",
-    "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-polyfill": "^6.9.0",
     "babel-preset-es2015": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.3.17",
     "babel-loader": "^6.2.0",
+    "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-polyfill": "^6.9.0",
     "babel-preset-es2015": "^6.3.13",

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,5 @@
 export const CONTROLLER_URL = process.env.CONTROLLER_SERVICE ?
-  process.env.CONTROLLER_SERVICE : 'https://notset';
+  `${process.env.CONTROLLER_SERVICE}/api/v1` : 'https://notset/api/v1';
 
 export const callApi = (endpoint, {
   apiUrl = CONTROLLER_URL,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,7 @@
+export const CONTROLLER_URL = __CONTROLLER_API__;
+
 export const callApi = (endpoint, {
-  apiUrl = __CONTROLLER_API__,
+  apiUrl = CONTROLLER_URL,
   headers = { 'Content-Type': 'application/json' },
   method = 'GET',
   body,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,8 +1,5 @@
-export const CONTROLLER_URL = process.env.CONTROLLER_SERVICE ?
-  `${process.env.CONTROLLER_SERVICE}/api/v1` : 'https://notset/api/v1';
-
 export const callApi = (endpoint, {
-  apiUrl = CONTROLLER_URL,
+  apiUrl = __CONTROLLER_API__,
   headers = { 'Content-Type': 'application/json' },
   method = 'GET',
   body,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,5 @@
 export const CONTROLLER_URL = process.env.CONTROLLER_SERVICE ?
-  process.env.CONTROLLER_SERVICE : 'not set';
+  process.env.CONTROLLER_SERVICE : 'https://notset';
 
 export const callApi = (endpoint, {
   apiUrl = CONTROLLER_URL,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,6 +1,5 @@
-export const CONTROLLER_URL = __DEV__
-  ? 'https://dev-logistics-wizard.mybluemix.net/api/v1'
-  : 'https://logistics-wizard.mybluemix.net/api/v1';
+export const CONTROLLER_URL = process.env.CONTROLLER_SERVICE ?
+  process.env.CONTROLLER_SERVICE : 'not set';
 
 export const callApi = (endpoint, {
   apiUrl = CONTROLLER_URL,

--- a/src/static/manifest.yml
+++ b/src/static/manifest.yml
@@ -3,7 +3,6 @@
   - name: logistics-wizard
     memory: 64M
     buildpack: staticfile_buildpack
-    path: .
     host: logistics-wizard
     env:
       NODE_ENV: production

--- a/src/static/manifest.yml
+++ b/src/static/manifest.yml
@@ -3,7 +3,7 @@
   - name: logistics-wizard
     memory: 64M
     buildpack: staticfile_buildpack
-    path: ./dist/
-    host: logistics-wizard-demo
+    path: .
+    host: logistics-wizard
     env:
       NODE_ENV: production


### PR DESCRIPTION
Move the manifest to "static" so that it gets copied to "dist" on deploy. This makes the artifacts we need to move between BUILD and DEPLOY in the pipeline way smaller - and thus speed up the deployment of a new version.

Also the controller URL is now initialized from an environment variable injected during the "npm run deploy". No more hardcoded value.

Finally the host is set to logistics-wizard.

https://github.com/IBM-Bluemix/logistics-wizard-webui/issues/17