### PR TITLE
Fix login flow, and add mock API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-react": "^6.0.0",
+    "faker": "^3.1.0",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.4.5",
     "mock-css-modules": "^1.0.0",

--- a/src/modules/demos.js
+++ b/src/modules/demos.js
@@ -30,8 +30,8 @@ const ACTION_HANDLERS = {
     ...state,
     name: action.payload.name,
     guid: action.payload.guid,
-    id: action.payload.id,
-    roles: [{
+    users: [{
+      id: action.payload.users[0].id,
       username: action.payload.users[0].username,
       type: action.payload.users[0].roles[0].name,
     }],

--- a/src/modules/demos.test.js
+++ b/src/modules/demos.test.js
@@ -56,10 +56,11 @@ test('(Reducer) stores token on loginSuccess', reducerTest(
 const demoApiResponse = () => ({
   name: 'demo',
   guid: 'guid',
-  id: 'id',
+  id: 'demoid',
   users: [{
+    id: 'userid',
     username: 'johndoe',
-    roles: [{ name: 'Supply Chain Manager' }],
+    roles: [{ name: 'supplychainmanager' }],
   }],
 });
 
@@ -70,10 +71,10 @@ test('(Reducer) adds demo session to state on receiveDemoSuccess', reducerTest(
   {
     name: 'demo',
     guid: 'guid',
-    id: 'id',
-    roles: [{
+    users: [{
+      id: 'userid',
       username: 'johndoe',
-      type: 'Supply Chain Manager',
+      type: 'supplychainmanager',
     }],
   },
 ));

--- a/src/routes/Dashboard/modules/Dashboard.js
+++ b/src/routes/Dashboard/modules/Dashboard.js
@@ -55,7 +55,7 @@ export default dashboardReducer;
 // This is set up in `../index.js` as the key in  `injectSagas(store, { key: 'dashboard', sagas });`
 export const dashboardSelector = state => state.dashboard;
 
-function *watchGetAdminData() {
+export function *watchGetAdminData() {
   while (true) {
     const { guid } = yield take(GET_ADMIN_DATA);
     let demoState = yield select(demoSelector);
@@ -71,7 +71,7 @@ function *watchGetAdminData() {
       }
 
       try {
-        const { token } = yield call(api.login, demoState.id, demoState.guid);
+        const { token } = yield call(api.login, demoState.users[0].id, demoState.guid);
         yield put(loginSuccess(token));
         demoState = yield select(demoSelector);
       }

--- a/src/routes/Dashboard/modules/Dashboard.js
+++ b/src/routes/Dashboard/modules/Dashboard.js
@@ -1,4 +1,3 @@
-// import { delay } from 'redux-saga';
 import { call, take, put, select } from 'redux-saga/effects';
 import api from 'services';
 import { loginSuccess, receiveDemoSuccess, demoSelector } from 'modules/demos';
@@ -12,14 +11,14 @@ export const ADMIN_DATA_RECEIVED = 'Dashboard/ADMIN_DATA_RECEIVED';
 // ------------------------------------
 // Actions
 // ------------------------------------
-export const getAdminData = (value) => ({
+export const getAdminData = (guid) => ({
   type: GET_ADMIN_DATA,
-  payload: value,
+  guid,
 });
 
-export const adminDataReceived = (value) => ({
+export const adminDataReceived = (payload) => ({
   type: ADMIN_DATA_RECEIVED,
-  payload: value,
+  payload,
 });
 
 export const actions = {
@@ -58,11 +57,11 @@ export const dashboardSelector = state => state.dashboard;
 
 function *watchGetAdminData() {
   while (true) {
-    const { payload } = yield take(GET_ADMIN_DATA);
+    const { guid } = yield take(GET_ADMIN_DATA);
     let demoState = yield select(demoSelector);
-    if (demoState.guid !== payload) {
+    if (demoState.guid !== guid) {
       try {
-        const demoSession = yield call(api.getDemo, payload);
+        const demoSession = yield call(api.getDemo, guid);
         yield put(receiveDemoSuccess(demoSession));
         demoState = yield select(demoSelector);
       }
@@ -70,16 +69,16 @@ function *watchGetAdminData() {
         // console.log(error);
         // yield put(receiveDemoFailure(error));
       }
-    }
 
-    try {
-      const { token } = yield call(api.login, demoState.id, demoState.guid);
-      yield put(loginSuccess(token));
-      demoState = yield select(demoSelector);
-    }
-    catch (error) {
-      // console.log(error);
-      // yield put(loginFailure(error));
+      try {
+        const { token } = yield call(api.login, demoState.id, demoState.guid);
+        yield put(loginSuccess(token));
+        demoState = yield select(demoSelector);
+      }
+      catch (error) {
+        // console.log(error);
+        // yield put(loginFailure(error));
+      }
     }
 
     try {

--- a/src/routes/Dashboard/modules/Dashboard.test.js
+++ b/src/routes/Dashboard/modules/Dashboard.test.js
@@ -1,149 +1,112 @@
 import test from 'ava';
-
-test.todo('(Duck) write tests for Dashboard.');
-/*
-import nock from 'nock';
 import { reducerTest, actionTest } from 'redux-ava';
-import { delay } from 'redux-saga';
 import { call, take, select, put } from 'redux-saga/effects';
+import { loginSuccess, receiveDemoSuccess } from 'modules/demos';
+import api from 'services';
 import {
-  UPDATE_TITLE,
-  GET_QUOTE,
-  RECEIVE_QUOTE,
-  updateTitle,
-  getQuote,
-  receiveQuote,
+  GET_ADMIN_DATA,
+  ADMIN_DATA_RECEIVED,
+  getAdminData,
+  adminDataReceived,
   dashboardReducer,
+  watchGetAdminData,
   dashboardSelector,
-  fetchQuote, // This would normally come from an api caller module
-  watchGetQuote,
 } from './Dashboard';
 
-// This test would not normally be here, but the fetch api is included for this example to work.
-test('(API) fetchQuote', t => {
-  const apiUrl = 'http://quotes.rest';
-  const endpoint = '/qod.json?category=inspire';
-  const reply = {
-    contents: {
-      quotes: [{
-        quote: 'Quote of the day.',
-      }],
-    },
-  };
-
-  nock(apiUrl)
-    .get(endpoint)
-    .reply(200, reply);
-  return fetchQuote().then(response => {
-    t.deepEqual(response, reply.contents.quotes[0].quote);
-  });
+const adminDataPayload = () => ({
+  stores: [{ store: 'store stuff' }],
+  shipments: [{ shipment: 'shipment stuff' }],
 });
 
-test('(Constant) UPDATE_TITLE === "Dashboard/UPDATE_TITLE"', t => {
-  t.is(UPDATE_TITLE, 'Dashboard/UPDATE_TITLE');
+
+test('(Selector) returns the slice of state for dashboard.', t => {
+  t.deepEqual(dashboardSelector({ dashboard: { id: '123' } }), { id: '123' });
 });
 
-test('(Constant) GET_QUOTE === "Dashboard/GET_QUOTE"', t => {
-  t.is(GET_QUOTE, 'Dashboard/GET_QUOTE');
+test('(Constant) GET_ADMIN_DATA === "Dashboard/GET_ADMIN_DATA"', t => {
+  t.is(GET_ADMIN_DATA, 'Dashboard/GET_ADMIN_DATA');
 });
 
-test('(Constant) RECEIVE_QUOTE === "Dashboard/RECEIVE_QUOTE"', t => {
-  t.is(RECEIVE_QUOTE, 'Dashboard/RECEIVE_QUOTE');
+test('(Constant) ADMIN_DATA_RECEIVED === "Dashboard/ADMIN_DATA_RECEIVED"', t => {
+  t.is(ADMIN_DATA_RECEIVED, 'Dashboard/ADMIN_DATA_RECEIVED');
 });
 
-test('(Action) updateTitle',
-  actionTest(updateTitle, 'title text', { type: UPDATE_TITLE, payload: 'title text' }));
+test('(Action) getAdminData',
+  actionTest(
+    getAdminData,
+    'guid string',
+    { type: GET_ADMIN_DATA, guid: 'guid string' })
+  );
 
-test('(Action) getQuote',
-  actionTest(getQuote, undefined, { type: GET_QUOTE }));
+test('(Action) getAdminData',
+  actionTest(
+    adminDataReceived,
+    { stores: [{ data: 'data' }] },
+    { type: ADMIN_DATA_RECEIVED, payload: { stores: [{ data: 'data' }] } })
+  );
 
-test('(Action) receiveQuote',
-  actionTest(receiveQuote, 'quote text', { type: RECEIVE_QUOTE, payload: 'quote text' }));
-
-test('(Reducer) initializes with title state', t => {
-  t.deepEqual(dashboardReducer(undefined, {}), { title: 'A Title Stored in global state.' });
+test('(Reducer) initializes with empty state', t => {
+  t.deepEqual(dashboardReducer(undefined, {}), {});
 });
-
-const testState = () => ({ title: 'A Title', quote: 'A Quote' });
 
 test('(Reducer) return previous state when no action is matched', reducerTest(
   dashboardReducer,
-  testState(),
+  { mock: 'mock' },
   { type: '@@@@@@@' },
-  testState()
+  { mock: 'mock' },
 ));
+
+test('(Reducer) spreads payload to state on adminDataReceived', reducerTest(
+  dashboardReducer,
+  {},
+  adminDataReceived(adminDataPayload()),
+  adminDataPayload(),
+));
+
 
 test('(Reducer) doesnt try to handle saga', reducerTest(
   dashboardReducer,
-  testState(),
-  getQuote,
-  testState(),
+  { mock: 'mock' },
+  getAdminData,
+  { mock: 'mock' },
 ));
 
-test('(Reducer) updates title', reducerTest(
-  dashboardReducer,
-  testState(),
-  updateTitle('New Title'),
-  { title: 'New Title', quote: 'A Quote' }
-));
+/*
+test('(Saga) watchGetAdminData - API Success', t => {
+  const saga = watchGetAdminData();
+  const payload = adminDataPayload();
+  const createDemoAction = getAdminData(payload);
+  const demoSession = { mockResponse: 'blah blah' };
+  const demoState = { guid: '1234' };
 
-test('(Reducer) updates quote', reducerTest(
-  dashboardReducer,
-  testState(),
-  receiveQuote('New Quote'),
-  { title: 'A Title', quote: 'New Quote' }
-));
-
-test('(Saga) watchGetQuote: no quote received.', t => {
-  const saga = watchGetQuote();
-  const state = {
-    title: 'Initial Title',
-  };
-  const mockQuote = 'A Very Insightful Quote.';
-
-  t.deepEqual(saga.next().value, take(GET_QUOTE),
-    'listens for GET_QUOTE action.');
-
-  t.deepEqual(saga.next().value, select(dashboardSelector),
-    'grabs the current state.');
-
-  t.deepEqual(saga.next(state).value, put(updateTitle('You dispatched an action!')),
-    'updates title.');
-
-  t.deepEqual(saga.next().value, put(receiveQuote('Fetching Quote...')),
-    'quote message updates with fetching message.');
-
-  t.deepEqual(saga.next().value, call(fetchQuote),
-    'calls fetchQuote api.');
-
-  t.deepEqual(saga.next(mockQuote).value, call(delay, 1000),
-    'simulates long load time by calling delay.');
-
-  t.deepEqual(saga.next().value, put(receiveQuote(mockQuote)),
-    'updates quote in state with quote received from api.');
-
-  t.deepEqual(saga.next().value, take(GET_QUOTE),
-    'loops back to listening for GET_QUOTE action.');
+  t.deepEqual(saga.next().value, take(GET_ADMIN_DATA),
+    'listens for GET_ADMIN_DATA action.');
+  t.deepEqual(saga.next(createDemoAction).value, call(api.createDemo, payload.name, payload.email),
+    'calls api with action payload as params.');
+  t.deepEqual(saga.next(demoSession).value, put(receiveDemoSuccess(demoSession)),
+    'dispatches receiveDemoSuccess action.');
+  t.deepEqual(saga.next().value, select(demoSelector),
+    'gets the updated state.');
+  t.deepEqual(saga.next(demoState).value, put(push(`/dashboard/${demoState.guid}`)),
+    'dispatches route change to dashboard');
+  t.deepEqual(saga.next().value, take(CREATE_DEMO),
+    'saga resets, and begins listening for CREATE_DEMO again.');
 });
 
-test('(Saga) watchGetQuote: quote already received.', t => {
-  const saga = watchGetQuote();
-  const state = {
-    title: 'You dispatched an action!',
-    quote: 'Insightful quote of the day',
-  };
+test.todo('Build a meaningful action around api failure.');
+test('(Saga) watchCreateDemo - API Failure', t => {
+  const saga = watchCreateDemo();
+  const payload = { name: 'test demo', email: 'name@email.com' };
+  const createDemoAction = createDemo(payload);
+  const error = { message: 'bad email' };
 
-  t.deepEqual(saga.next().value, take(GET_QUOTE),
-    'listens for GET_QUOTE action.');
-
-  t.deepEqual(saga.next().value, select(dashboardSelector),
-    'grabs the current state.');
-
-  t.deepEqual(saga.next(state).value, put(updateTitle('You already have a quote.')),
-    'grabs the current state.');
-
-  t.deepEqual(saga.next().value, take(GET_QUOTE),
-    'loops back to listening for GET_QUOTE action.');
+  t.deepEqual(saga.next().value, take(CREATE_DEMO),
+    'listens for CREATE_DEMO action.');
+  t.deepEqual(saga.next(createDemoAction).value, call(api.createDemo, payload.name, payload.email),
+    'calls api with action payload as params.');
+  t.deepEqual(saga.throw(error).value, put(createDemoFailure(error)),
+    'dispatches createDemoFailure if api call fails.');
+  t.deepEqual(saga.next().value, take(CREATE_DEMO),
+    'saga resets, and begins listening for CREATE_DEMO again.');
 });
-
 */

--- a/src/services/mockApi.js
+++ b/src/services/mockApi.js
@@ -1,0 +1,80 @@
+import faker from 'faker';
+
+export const getDemo = ({
+  guid = faker.random.uuid(),
+} = {}) => ({
+  createdAt: faker.date.recent(),
+  name: faker.fake('{{lorem.word}} {{random.number}}'),
+  guid,
+  id: faker.random.number(),
+  users: [{
+    username: faker.name.firstName(),
+    email: faker.internet.email(),
+    created: null,
+    id: faker.random.number(),
+    demoId: faker.random.number(),
+    roles: [{
+      id: 1,
+      name: 'supplychainmanager',
+      description: null,
+      created: faker.date.recent(),
+      modified: faker.date.recent(),
+    }],
+  }],
+});
+
+export const login = () => ({
+  token: faker.random.uuid(),
+});
+
+export const getAdminData = () => ({
+  'distribution-centers': [{
+    contact: {
+      name: faker.fake('{{name.firstName}} {{name.lastName}}'),
+    },
+    address: {
+      state: faker.address.state(),
+      city: faker.address.city(),
+      latitude: faker.address.latitude(),
+      country: faker.address.country(),
+      longitude: faker.address.longitude(),
+    },
+    id: 1,
+  }],
+  shipments: [{
+    id: faker.random.number(),
+    fromId: 1,
+    status: 'APPROVED',
+    createdAt: Date.now(),
+    deliveredAt: null,
+    currentLocation: {
+      state: faker.address.state(),
+      city: faker.address.city(),
+      latitude: faker.address.latitude(),
+      country: faker.address.country(),
+      longitude: faker.address.longitude(),
+    },
+    estimatedTimeOfArrival: faker.date.future(),
+    toId: 405,
+    updatedAt: null,
+  }],
+  retailers: [{
+    managerId: null,
+    address: {
+      state: faker.address.state(),
+      city: faker.address.city(),
+      latitude: faker.address.latitude(),
+      country: faker.address.country(),
+      longitude: faker.address.longitude(),
+    },
+    id: 405,
+  }],
+});
+
+export const mockApi = {
+  getDemo,
+  login,
+  getAdminData,
+};
+
+export default mockApi;


### PR DESCRIPTION
closes #21 
The previous login saga was using the demo ID, instead of the userid.
When updating the code, I realized I didn't have a way for the saga tests to fail if the State changes from what I expected it to be when I wrote the tests...so I now use reducers and mock api responses to more accurately represent what is happening (and mostly have the tests fail properly)