### PR TITLE
Show distribution center and retailer names when needed

### DIFF
--- a/src/routes/Dashboard/components/Map/PopUpCard/DCCard/DCCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/DCCard/DCCard.jsx
@@ -7,7 +7,19 @@ import {
 } from 'material-ui/Table';
 import classes from '../PopUpCard.scss';
 
-const DCCard = ({ address, contact, shipments }) => (
+const styles = {
+  column: {
+    padding: '0rem',
+    height: '30px',
+  },
+  column2: {
+    padding: '0rem',
+    height: '30px',
+    fontStyle: 'italic',
+  },
+};
+
+const DCCard = ({ address, contact, shipments, idToNameResolver }) => (
   <div>
     <div className={classes.header}>
       <div className={classes.headerLine}>
@@ -26,14 +38,14 @@ const DCCard = ({ address, contact, shipments }) => (
             Outgoing Shipments ({shipments.length})
           </h4>
         </div>
-        <hr />
         <div style={{ padding: '0 1rem' }}>
+          <hr />
           <Table>
             <TableBody displayRowCheckbox={false}>
               {shipments.map(shipment => (
                 <TableRow>
-                  <TableRowColumn style={{ paddingLeft: '0' }}>{shipment.id}</TableRowColumn>
-                  <TableRowColumn style={{ fontStyle: 'italic' }}>{shipment.status}</TableRowColumn>
+                  <TableRowColumn style={styles.column}>{idToNameResolver.resolve('retailer', shipment.toId)}</TableRowColumn>
+                  <TableRowColumn style={styles.column2}>{shipment.status}</TableRowColumn>
                 </TableRow>
               ))}
             </TableBody>
@@ -58,6 +70,7 @@ DCCard.propTypes = {
     id: React.PropTypes.string.isRequired,
     status: React.PropTypes.string.isRequired,
   })),
+  idToNameResolver: React.PropTypes.object,
 };
 
 export default DCCard;

--- a/src/routes/Dashboard/components/Map/PopUpCard/DCCard/DCCard.story.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/DCCard/DCCard.story.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import DCCard from './DCCard';
 
+const resolver = {
+  resolve: (type, id) => `${type} ${id}`,
+};
+
 const dc1 = {
   contact: 'Joseph Smith',
   id: 1,
@@ -30,5 +34,9 @@ const dc1 = {
 
 storiesOf('DCCard', module)
   .add('dc1', () => (
-    <DCCard contact={dc1.contact} id={dc1.id} address={dc1.address} shipments={dc1.shipments} />
+    <DCCard
+      contact={dc1.contact} id={dc1.id}
+      address={dc1.address} shipments={dc1.shipments}
+      idToNameResolver={resolver}
+    />
   ));

--- a/src/routes/Dashboard/components/Map/PopUpCard/PopUpCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/PopUpCard.jsx
@@ -48,7 +48,10 @@ const showSelectedInfo = (dashboard) => { // eslint-disable-line
   }
   else if (dashboard.infoBox.type === 'storm') {
     return (
-      <StormCard storm={dashboard.storms[0]} />
+      <StormCard
+        storm={dashboard.storms[0]}
+        idToNameResolver={NameResolver(dashboard)}
+      />
     );
   }
   else if (dashboard.infoBox.type === 'hidden') {

--- a/src/routes/Dashboard/components/Map/PopUpCard/PopUpCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/PopUpCard.jsx
@@ -6,6 +6,7 @@ import ShipmentCard from './ShipmentCard';
 import RetailerCard from './RetailerCard';
 import StormCard from './StormCard';
 import DCCard from './DCCard';
+import NameResolver from '../../NameResolver';
 
 const showSelectedInfo = (dashboard) => { // eslint-disable-line
   if (dashboard.infoBox.type === 'distributionCenter') {
@@ -18,6 +19,7 @@ const showSelectedInfo = (dashboard) => { // eslint-disable-line
         contact={selectedDc.contact.name}
         address={selectedDc.address}
         shipments={shipments}
+        idToNameResolver={NameResolver(dashboard)}
       />
     );
   }
@@ -25,7 +27,10 @@ const showSelectedInfo = (dashboard) => { // eslint-disable-line
     const selectedShipment = dashboard.shipments
       .find(shipment => shipment.id === dashboard.infoBox.data.id);
     return (
-      <ShipmentCard shipment={selectedShipment} />
+      <ShipmentCard
+        shipment={selectedShipment}
+        idToNameResolver={NameResolver(dashboard)}
+      />
     );
   }
   else if (dashboard.infoBox.type === 'retailer') {
@@ -34,7 +39,11 @@ const showSelectedInfo = (dashboard) => { // eslint-disable-line
     const shipments = dashboard.shipments
       .filter(shipment => shipment.toId === selectedRetailer.id);
     return (
-      <RetailerCard retailer={selectedRetailer} shipments={shipments} />
+      <RetailerCard
+        retailer={selectedRetailer}
+        shipments={shipments}
+        idToNameResolver={NameResolver(dashboard)}
+      />
     );
   }
   else if (dashboard.infoBox.type === 'storm') {

--- a/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.jsx
@@ -75,7 +75,7 @@ export class RetailerCard extends React.PureComponent {
                 <TableBody displayRowCheckbox={false}>
                   {shipments.map(shipment => (
                     <TableRow>
-                      <TableRowColumn style={styles.column}>{shipment.id}</TableRowColumn>
+                      <TableRowColumn style={styles.column}>{this.props.idToNameResolver.resolve('distributionCenter', shipment.fromId)}</TableRowColumn>
                       <TableRowColumn style={styles.column2}>{shipment.status}</TableRowColumn>
                     </TableRow>
                   ))}
@@ -99,6 +99,7 @@ export class RetailerCard extends React.PureComponent {
 RetailerCard.propTypes = {
   retailer: React.PropTypes.object.isRequired,
   shipments: React.PropTypes.array,
+  idToNameResolver: React.PropTypes.object,
   retrieveWeatherObservations: React.PropTypes.func.isRequired,
 };
 

--- a/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.story.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.story.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { RetailerCard } from './RetailerCard';
 
+const resolver = {
+  resolve: (type, id) => `${type} ${id}`,
+};
+
 const props1 = {
   retailer: {
     id: 1261,
@@ -32,7 +36,7 @@ const props2 = {
 };
 storiesOf('RetailerCard', module)
   .add('retailer1', () => (
-    <RetailerCard {...props1} />
+    <RetailerCard {...props1} idToNameResolver={resolver} />
 )).add('retailer2', () => (
-  <RetailerCard {...props2} />
+  <RetailerCard {...props2} idToNameResolver={resolver} />
 ));

--- a/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.test.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/RetailerCard/RetailerCard.test.js
@@ -7,6 +7,9 @@ const setup = () => {
   const spies = {
   };
   const props = {
+    idToNameResolver: {
+      resolve: (type, id) => `${type} ${id}`,
+    },
     retailer: {
       id: 1261,
       managerId: null,
@@ -33,6 +36,9 @@ test('(Component) Renders with expected elements', t => {
 });
 
 const propsWithShipments = {
+  idToNameResolver: {
+    resolve: (type, id) => `${type} ${id}`,
+  },
   retailer: {
     id: 1261,
     managerId: null,

--- a/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.jsx
@@ -35,6 +35,8 @@ export class ShipmentCard extends React.PureComponent {
       currentLocation,
       estimatedTimeOfArrival,
       updatedAt,
+      fromId,
+      toId,
     } = this.props.shipment;
 
     return (
@@ -55,15 +57,29 @@ export class ShipmentCard extends React.PureComponent {
           </div>
           }
 
-        <div className={classes.subtitle2}>
-          Estimated Time of Arrival
-        </div>
-        <div>{formatTime(estimatedTimeOfArrival)}</div>
+        { status !== 'DELIVERED' &&
+          <div>
+            <div className={classes.subtitle2}>
+              Estimated Time of Arrival
+            </div>
+            <div>{formatTime(estimatedTimeOfArrival)}</div>
+          </div>
+        }
 
         <div className={classes.subtitle2}>
           Last Updated
         </div>
         <div>{updatedAt ? formatTime(updatedAt) : 'N/A'}</div>
+
+        <div className={classes.subtitle2}>
+          Origin
+        </div>
+        <div>{this.props.idToNameResolver.resolve('distributionCenter', fromId)}</div>
+
+        <div className={classes.subtitle2}>
+          Destination
+        </div>
+        <div>{this.props.idToNameResolver.resolve('retailer', toId)}</div>
 
         {currentLocation &&
           <div>
@@ -85,6 +101,7 @@ export class ShipmentCard extends React.PureComponent {
 ShipmentCard.propTypes = {
   shipment: React.PropTypes.object.isRequired,
   retrieveWeatherObservations: React.PropTypes.func.isRequired,
+  idToNameResolver: React.PropTypes.object,
 };
 
 const mapActionCreators = {

--- a/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.story.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.story.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { ShipmentCard } from './ShipmentCard';
 
+const resolver = {
+  resolve: (type, id) => `${type} ${id}`,
+};
+
 const props1 = {
   shipment: {
     toId: 462,
@@ -35,9 +39,13 @@ const shipment2 = {
 };
 storiesOf('ShipmentCard', module)
   .add('shipment1', () => (
-    <ShipmentCard {...props1} />
+    <ShipmentCard
+      {...props1}
+      idToNameResolver={resolver}
+    />
 )).add('shipment2', () => (
   <ShipmentCard
     shipment={shipment2}
+    idToNameResolver={resolver}
   />
   ));

--- a/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.test.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/ShipmentCard/ShipmentCard.test.js
@@ -5,6 +5,9 @@ import { ShipmentCard } from './ShipmentCard';
 
 test('(Component) ShipmentCard shows a progress when no weather data.', t => {
   const props = {
+    idToNameResolver: {
+      resolve: (type, id) => `${type} ${id}`,
+    },
     shipment: {
       toId: 462,
       estimatedTimeOfArrival: '2016-10-22T00:00:00.000Z',
@@ -30,6 +33,9 @@ test('(Component) ShipmentCard shows a progress when no weather data.', t => {
 
 test('(Component) ShipmentCard shows current weather when it exists.', t => {
   const props = {
+    idToNameResolver: {
+      resolve: (type, id) => `${type} ${id}`,
+    },
     shipment: {
       toId: 462,
       estimatedTimeOfArrival: '2016-10-22T00:00:00.000Z',

--- a/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.jsx
+++ b/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.jsx
@@ -47,7 +47,7 @@ export const StormCard = (props) => {
         {recommendations.map(recommendation =>
           <div className={classes.shipmentDialog} key={recommendation._id}>
             <div className={classes.shipmentTitle}>
-              Shipment from {recommendation.fromId} to {recommendation.toId}
+              Shipment from {props.idToNameResolver.resolve('distributionCenter', recommendation.fromId)} to {props.idToNameResolver.resolve('retailer', recommendation.toId)}
             </div>
             <div className={classes.shipmentDialogActionContainer}>
               <div
@@ -72,6 +72,7 @@ export const StormCard = (props) => {
 
 StormCard.propTypes = {
   storm: React.PropTypes.object.isRequired,
+  idToNameResolver: React.PropTypes.object,
 };
 
 const mapActionCreators = {

--- a/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.story.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.story.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
-import StormCard from './StormCard';
+import { StormCard } from './StormCard';
+
+const resolver = {
+  resolve: (type, id) => `${type} ${id}`,
+};
 
 const storm1 = {
   event: {
@@ -85,5 +89,6 @@ storiesOf('StormCard', module)
   .add('storm1', () => (
     <StormCard
       storm={storm1}
+      idToNameResolver={resolver}
     />
 ));

--- a/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.test.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.test.js
@@ -7,6 +7,9 @@ const setup = () => {
   const spies = {
   };
   const props = {
+    idToNameResolver: {
+      resolve: (type, id) => `${type} ${id}`,
+    },
     storm: {
       event: {
         area_id: 'CAZ048',

--- a/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.test.js
+++ b/src/routes/Dashboard/components/Map/PopUpCard/StormCard/StormCard.test.js
@@ -89,7 +89,7 @@ const setup = () => {
       ],
     },
   };
-  const component = shallow(<StormCard storm={props.storm} />);
+  const component = shallow(<StormCard {...props} />);
 
   return { spies, props, component };
 };

--- a/src/routes/Dashboard/components/NameResolver.jsx
+++ b/src/routes/Dashboard/components/NameResolver.jsx
@@ -1,0 +1,16 @@
+export const NameResolver = (dashboard) => ({
+  resolve: (type, id) => {
+    switch (type) {
+      case 'distributionCenter':
+        return dashboard['distribution-centers']
+          .find(dc => dc.id === id).address.city;
+      case 'retailer':
+        return dashboard.retailers
+          .find(retailer => retailer.id === id).address.city;
+      default:
+        return `*${id}*`;
+    }
+  },
+});
+
+export default NameResolver;

--- a/src/routes/Dashboard/components/NameResolver.test.js
+++ b/src/routes/Dashboard/components/NameResolver.test.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import NameResolver from './NameResolver';
+
+const dashboard = {
+  'distribution-centers': [
+    {
+      id: 1,
+      address: {
+        city: 'DC',
+      },
+    },
+  ],
+  retailers: [
+    {
+      id: 1,
+      address: {
+        city: 'Retailer',
+      },
+    },
+  ],
+};
+
+test('Resolves names', t => {
+  t.is('DC', NameResolver(dashboard).resolve('distributionCenter', 1));
+  t.is('Retailer', NameResolver(dashboard).resolve('retailer', 1));
+  t.is('*123*', NameResolver(dashboard).resolve('unknownType', 123));
+});

--- a/src/routes/Dashboard/components/ShipmentsTable/ShipmentsTable.jsx
+++ b/src/routes/Dashboard/components/ShipmentsTable/ShipmentsTable.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { palette } from 'styles/muiTheme';
 import { selectMarker } from 'routes/Dashboard/modules/Dashboard';
+import NameResolver from '../NameResolver';
 
 import {
   Table,
@@ -39,10 +40,11 @@ const styles = {
 
 export class ShipmentsTable extends React.PureComponent {
 
-  handleClick = (rowNumber) => this.props.selectMarker('shipment', this.props.shipments[rowNumber]);
+  handleClick = (rowNumber) => this.props.selectMarker('shipment', this.props.dashboard.shipments[rowNumber]);
 
   render() {
     const props = this.props;
+    const idToNameResolver = NameResolver(this.props.dashboard);
     return (
       <Table
         wrapperStyle={styles.wrapper}
@@ -52,20 +54,22 @@ export class ShipmentsTable extends React.PureComponent {
           <TableRow>
             <TableHeaderColumn style={styles.header}>Shipment #</TableHeaderColumn>
             <TableHeaderColumn style={styles.header}>Status</TableHeaderColumn>
+            <TableHeaderColumn style={styles.header}>Origin</TableHeaderColumn>
             <TableHeaderColumn style={styles.header}>Destination</TableHeaderColumn>
             <TableHeaderColumn style={styles.header}>Date Placed</TableHeaderColumn>
             <TableHeaderColumn style={styles.header}>Estimated Time of Arrival</TableHeaderColumn>
           </TableRow>
         </TableHeader>
         <TableBody displayRowCheckbox={false}>
-          {props.shipments.map(shipment =>
+          {props.dashboard.shipments.map(shipment =>
             <TableRow
               key={shipment.id}
               style={{ padding: '40px' }}
             >
               <TableRowColumn>{shipment.id}</TableRowColumn>
               <TableRowColumn>{shipment.status}</TableRowColumn>
-              <TableRowColumn>{shipment.toId}</TableRowColumn>
+              <TableRowColumn>{idToNameResolver.resolve('distributionCenter', shipment.fromId)}</TableRowColumn>
+              <TableRowColumn>{idToNameResolver.resolve('retailer', shipment.toId)}</TableRowColumn>
               <TableRowColumn>{moment(shipment.createdAt).format(timeFormat)}</TableRowColumn>
               <TableRowColumn>
                 {moment(shipment.estimatedTimeOfArrival).format(timeFormat)}
@@ -81,7 +85,7 @@ export class ShipmentsTable extends React.PureComponent {
 
 ShipmentsTable.propTypes = {
   selectMarker: React.PropTypes.func.isRequired,
-  shipments: React.PropTypes.array,
+  dashboard: React.PropTypes.object,
 };
 
 // ------------------------------------
@@ -92,7 +96,7 @@ const mapActionCreators = {
 };
 
 const mapStateToProps = (state) => ({
-  shipments: state.dashboard.shipments,
+  dashboard: state.dashboard,
 });
 
 


### PR DESCRIPTION
introduce NameResolver object used by components to resolve display names for a given object type and id (avoid to replicate the same code in all components, and does not require them to have a dependency on the dashboard through state).

https://github.com/IBM-Bluemix/logistics-wizard/issues/242
https://github.com/IBM-Bluemix/logistics-wizard/issues/244