### PR TITLE
font-awesome bug: Don't ignore node_modules

### DIFF
--- a/.csignore
+++ b/.csignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
font-awesome fonts are stored in node_modules folder